### PR TITLE
Accounting for modules deprecated in Django 1.6

### DIFF
--- a/ella_flatcomments/urls.py
+++ b/ella_flatcomments/urls.py
@@ -1,6 +1,9 @@
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext as _
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except:
+    from django.conf.urls.defaults import patterns, url
 
 from ella_flatcomments.views import list_comments, post_comment, comment_detail, moderate_comment, lock_comments, unlock_comments
 


### PR DESCRIPTION
Import statement is backwards compatible with Django 1.4 and older.
